### PR TITLE
correct UserWarning

### DIFF
--- a/train.py
+++ b/train.py
@@ -47,7 +47,7 @@ def parse_arguments():
                         default=4, help="The number of workers for the dataloaders"
                                         " i.e. the number of additional"
                                         " dedicated threads to dataloading.")
-    parser.add_argument('-f', '--imutils_flag', default='fast', type=str,
+    parser.add_argument('-f', '--imutils_flag', default='safe', type=str,
                         choices=imutils.VALID_FLAGS,
                         help="Optional, the flag of the image_utils defining "
                         "the image processing tools.")

--- a/training/losses.py
+++ b/training/losses.py
@@ -16,5 +16,5 @@ def BCELogit_Loss(score_map, labels):
     labels = labels.unsqueeze(1)
     loss = F.binary_cross_entropy_with_logits(score_map, labels[:, :, :, :, 0],
                                               weight=labels[:, :, :, :, 1],
-                                              reduction='elementwise_mean')
+                                              reduction='mean')
     return loss


### PR DESCRIPTION
Have this warning: 
" /usr/local/lib/python3.6/dist-packages/torch/nn/_reduction.py:16: UserWarning: reduction='elementwise_mean' is deprecated, please use reduction='mean' instead. warnings.warn("reduction='elementwise_mean' is deprecated, please use reduction='mean' instead.") ", and " AssertionError: [IMAGE-UTILS] Error: It seems that the used image utils flag is not available, try setting the flag to 'safe'. "
don't know useful for you or not (: 